### PR TITLE
Move SocialShare away from the default config section

### DIFF
--- a/app/code/community/SocialShare/OpenGraphTags/etc/system.xml
+++ b/app/code/community/SocialShare/OpenGraphTags/etc/system.xml
@@ -11,7 +11,7 @@
       <label>Basic Configuration</label>
       <tab>socialshare</tab>
       <frontend_type>text</frontend_type>
-      <sort_order>10</sort_order>
+      <sort_order>1000</sort_order>
       <show_in_default>1</show_in_default>
       <show_in_website>1</show_in_website>
       <show_in_store>1</show_in_store>


### PR DESCRIPTION
Magento defaults to the lowest numbered section (even if it's not in the lowest numbered tab.)  This doesn't match the visual experience of "General" being first.
